### PR TITLE
Delete all related crumbs when object is deleted.

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/lib/redcrumbs.rb
+++ b/lib/redcrumbs.rb
@@ -38,7 +38,7 @@ require 'dm-core'
 module Redcrumbs
   extend ActiveSupport::Concern
   extend ActiveSupport::Autoload
-  
+
   autoload :Options
   autoload :Users
   autoload :Creation
@@ -46,7 +46,7 @@ module Redcrumbs
 
   include Options
   include Users
-  
+
   def self.setup
     yield self
   end
@@ -54,13 +54,13 @@ module Redcrumbs
   def self.included(base)
     base.extend(ClassMethods)
   end
-  
+
   module ClassMethods
     def redcrumbed(options = {})
       include Creation
-      
+
       prepare_redcrumbed_options(options)
-      
+
       after_save :notify_changes, self.redcrumbs_callback_options
 
     end

--- a/spec/redcrumbs/creation_spec.rb
+++ b/spec/redcrumbs/creation_spec.rb
@@ -11,24 +11,40 @@ describe Redcrumbs::Creation do
       it { expect(subject.crumbs.count).to eq(1) }
     end
 
-    context 'when single tracked attribute updated' do
-      it do 
+    context 'when deleted' do
+
+      # Generate more crumbs
+      before do
+        subject.update_attributes(:highscore => 12935)
+        subject.update_attributes(:name => 'Paperboy 2')
+      end
+
+      it do
+        total_crumbs = subject.crumbs.count
         expect {
-          subject.update_attributes(:highscore => 12935) 
+          subject.destroy
+        }.to change { subject.crumbs.count }.by(-total_crumbs)
+      end
+    end
+
+    context 'when single tracked attribute updated' do
+      it do
+        expect {
+          subject.update_attributes(:highscore => 12935)
         }.to change { subject.crumbs.count }.by(1)
       end
     end
 
     context 'when multiple tracked attributes updated' do
-      it do 
+      it do
         expect {
-          subject.update_attributes(:highscore => 12935, :name => 'Paperboy 2') 
+          subject.update_attributes(:highscore => 12935, :name => 'Paperboy 2')
         }.to change { subject.crumbs.count }.by(1)
       end
     end
 
     context 'when updated twice' do
-      it do 
+      it do
         expect {
           subject.update_attributes(:highscore => 12935)
           subject.update_attributes(:name => 'Paperboy 2')
@@ -37,7 +53,7 @@ describe Redcrumbs::Creation do
     end
 
     context 'when untracked attribute updated' do
-      it do 
+      it do
         expect {
           subject.update_attributes(:platform => 'Commodore 64')
         }.to change { subject.crumbs.count }.by(0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,10 @@ RSpec.configure do |c|
   end
 
   c.mock_with :rspec
+
+  c.filter_run focus: true
+  c.run_all_when_everything_filtered = true
+
 end
 
 Dir[File.expand_path('../support/*.rb', __FILE__)].each{|f| require f }


### PR DESCRIPTION
This PR fixes the issue #25 by deleting all the related crumbs when the object is deleted.
