### PR TITLE
Fix Rails 5.0 deprecation warning.

### DIFF
--- a/spec/support/schema.rb
+++ b/spec/support/schema.rb
@@ -7,12 +7,12 @@ class CreateSchema < ActiveRecord::Migration
   def self.up
     create_table :computer_players, :force => true do |t|
       t.string :name
-      t.timestamps
+      t.timestamps null: true
     end
 
     create_table :players, :force => true do |t|
       t.string :name
-      t.timestamps
+      t.timestamps null: true
     end
 
     create_table :games, :force => true do |t|
@@ -20,7 +20,7 @@ class CreateSchema < ActiveRecord::Migration
       t.string :name
       t.string :platform
       t.integer :highscore
-      t.timestamps
+      t.timestamps null: true
     end
   end
 end


### PR DESCRIPTION
Removes the following deprecation warning when running tests:

```
DEPRECATION WARNING: `#timestamps` was called without specifying an option for `null`. In Rails 5, this behavior will change to `null: false`. You should manually specify `null: true` to prevent the behavior of your existing migrations from changing.
```